### PR TITLE
Io check

### DIFF
--- a/minpy/nn/io.py
+++ b/minpy/nn/io.py
@@ -4,7 +4,8 @@ from __future__ import absolute_import
 from collections import OrderedDict
 
 import sys, inspect
-import numpy as np
+import minpy.numpy as np
+import numpy as ori_np
 import six.moves.cPickle as pickle
 import minpy
 import mxnet.io
@@ -168,7 +169,7 @@ class NDArrayIter(DataIter):
 
         # shuffle data
         if shuffle:
-            idx = np.arange(self.data[0][1].shape[0])
+            idx = ori_np.arange(self.data[0][1].shape[0])
             np.random.shuffle(idx)
             self.data = [(k, v[idx]) for k, v in self.data]
             self.label = [(k, v[idx]) for k, v in self.label]
@@ -249,9 +250,9 @@ class NDArrayIter(DataIter):
         else:
             pad = self.batch_size - self.num_data + self.cursor
             if isinstance(data_source[0][1], minpy.array.Array):
-                return [minpy.array.Array(np.concatenate((x[1][self.cursor:].asnumpy(), x[1][:pad].asnumpy()), axis=0)) for x in data_source]
+                return [minpy.array.Array(ori_np.concatenate((x[1][self.cursor:].asnumpy(), x[1][:pad].asnumpy()), axis=0)) for x in data_source]
             elif isinstance(data_source[0][1], np.ndarray):
-                return [minpy.array.Array(np.concatenate((x[1][self.cursor:], x[1][:pad]), axis=0)) for x in data_source]
+                return [minpy.array.Array(ori_np.concatenate((x[1][self.cursor:], x[1][:pad]), axis=0)) for x in data_source]
             else:
                 raise TypeError("Invalid data type, only numpy.ndarray and minpy.array.Array are allowed.")
 
@@ -271,7 +272,7 @@ class NDArrayIter(DataIter):
 
     def getsubiter(self, num_samples):
         """Create a sub dataiter which samples part of the data in the dataset"""
-        idx = np.arange(self.data[0][1].shape[0])
+        idx = ori_np.arange(self.data[0][1].shape[0])
         np.random.shuffle(idx)
         mask = idx[0:num_samples]
         data = [v[mask] for k, v in self.data]

--- a/minpy/nn/solver.py
+++ b/minpy/nn/solver.py
@@ -221,7 +221,7 @@ class Solver(object):
                 each_batch.data[0], mode='test').asnumpy()
             acc_count += np.sum(
                 np.argmax(
-                    predict, axis=1) == each_batch.label[0])
+                    predict, axis=1) == each_batch.label[0].asnumpy())
             num_samples += check_dataiter.batch_size
         return float(acc_count) / num_samples
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -77,4 +77,32 @@ def test_NDArrayIter():
         else:
             assert(labelcount[i] == 100)
 
+    # check padding
+    datas = ori_np.ones([1000, 2, 2])
+    labels = ori_np.ones([1000, 1])
+    for i in range(1000):
+        datas[i] = i / 100
+        labels[i] = i / 100
+    dataiter = io.NDArrayIter(datas, labels, batch_size = 128, shuffle = True, last_batch_handle='pad')
+    batchidx = 0
+    for batch in dataiter:
+        batchidx += 1
+    assert(batchidx == 8)
+    dataiter = io.NDArrayIter(datas, labels, batch_size = 128, shuffle = False, last_batch_handle='pad')
+    batchidx = 0
+    labelcount = [0 for i in range(10)]
+    for batch in dataiter:  
+        label = batch.label[0].asnumpy().flatten()
+        assert((batch.data[0].asnumpy()[:,0,0] == label).all())
+        for i in range(label.shape[0]):
+            labelcount[int(label[i])] += 1
+
+    for i in range(10):
+        if i == 0:
+            assert(labelcount[i] == 124)
+        else:
+            assert(labelcount[i] == 100)
+
+
+
 test_NDArrayIter()


### PR DESCRIPTION
fix check_accuracy. In solver, we use numpy to process data, but the output of IO is minpy.array, which may cause trouble.