### PR TITLE
Fix is_train and multiple outputs for mxnet symbol

### DIFF
--- a/minpy/core.py
+++ b/minpy/core.py
@@ -111,10 +111,21 @@ class Function(object):
         :return: A function that could be called (and differentiated) as normal primitive.
         """
         self._symbol = symbol
+        self._is_train = True
         self._input_shapes = input_shapes
         if input_shapes is not None:
             self._infer_shape(input_shapes)
         self._sym_name = name
+
+    @property
+    def is_train(self):
+        """ whether this forward is for evaluation purpose. """
+        return self._is_train
+
+    @is_train.setter
+    def is_train(self, value):
+        """ whether this forward is for evaluation purpose. """
+        self._is_train = value
 
     def _infer_shape(self, input_shapes):
         # Infer shapes of parameters and outputs.
@@ -147,10 +158,8 @@ class Function(object):
                 if arg is not None:
                     arg.copyto(executor_arg)
             # Forward computation.
-            # TODO(haoran): How to set `is_train` flag
-            executor.forward(is_train=True)
-            # TODO(haoran): Currently doesn't support multiple outputs.
-            return executor.outputs[0]
+            executor.forward(is_train=self._is_train)
+            return tuple(executor.outputs) if len(executor.outputs) > 1 else executor.outputs[0]
         # Set function name to be the given symbol name.
         func.__name__ = self._sym_name
 


### PR DESCRIPTION
@GaiYu0 @sneakerkg @jermainewang Guys, please check.

Example to disable is_train (its default value is true)
```Python
  net = mx.sym.Flatten(net);
  net = mx.sym.FullyConnected(data=net, name='fc1', num_hidden=hidden_size);
  net = mx.sym.Activation(data=net, act_type='relu')
  net = mx.sym.FullyConnected(data=net, name='fc2', num_hidden=num_classes)
  net = mx.sym.SoftmaxOutput(data=net, name='softmax', normalization='batch')
  input_shapes = {'X': (batch_size,) + input_size, 'softmax_label': (batch_size,)} 
  self.fwd_fn = core.Function(net, input_shapes=input_shapes)
  self.fwd_fn.is_train(False)
```

Example to use multi-outputs
Say the above network has multiple outputs, you could access the outputs with index
```Python
  self.fwd_fn(inputs)[i]
```
When network is single-outputted, indexing would be unnecessary (back compatible). And you could just reference the value by 
```Python
  self.fwd_fn(inputs)
```
